### PR TITLE
fix: nostr-tools v2 compat and Brave extension context handling

### DIFF
--- a/dist/nostr-provider.js
+++ b/dist/nostr-provider.js
@@ -4,7 +4,10 @@ window.nostr = {
 
   async getPublicKey() {
     if (this._pubkey) return this._pubkey
-    this._pubkey = await this._call('getPublicKey', {})
+    // Don't cache on the promise itself – if the call rejects (e.g. context
+    // invalidated) _pubkey must stay null so the next call retries properly.
+    const pubkey = await this._call('getPublicKey', {})
+    this._pubkey = pubkey
     return this._pubkey
   },
 

--- a/src/background.jsx
+++ b/src/background.jsx
@@ -29,6 +29,20 @@ import {
 import { clearAllCaches as clearProfileCaches, persistEncryptedCachesWithKey, restoreEncryptedCachesWithKey } from './services/cache'
 import { closeDiscoveryPool } from './helpers/outbox'
 
+/**
+ * Convert a hex-encoded private key string to Uint8Array.
+ * nostr-tools v2 changed its API to require Uint8Array for all private key
+ * parameters (getPublicKey, finalizeEvent, nip04, nip44).  Vault data stores
+ * private keys as hex strings, so we convert at every call site.
+ */
+function hexToBytes(hex) {
+  const bytes = new Uint8Array(hex.length / 2)
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+  }
+  return bytes
+}
+
 let openPrompt = null
 let promptMutex = new Mutex()
 let releasePromptMutex = () => {}
@@ -343,7 +357,7 @@ function getSharedSecret(sk, peer) {
   let key = secretsCache.get(peer)
 
   if (!key) {
-    key = nip44.v2.utils.getConversationKey(sk, peer)
+    key = nip44.v2.utils.getConversationKey(hexToBytes(sk), peer)
     secretsCache.set(peer, key)
   }
 
@@ -381,7 +395,7 @@ function findAccountByPubkey(targetPubkey) {
 
   for (const account of allAccounts) {
     try {
-      if (getPublicKey(account.prvKey) === targetPubkey) {
+      if (getPublicKey(hexToBytes(account.prvKey)) === targetPubkey) {
         return account.prvKey
       }
     } catch (e) { /* skip invalid keys */ }
@@ -962,7 +976,7 @@ function handleGetAccountsList() {
   const derivedAccounts = privateMaterial.accounts || []
   for (let i = 0; i < derivedAccounts.length; i++) {
     const prvKey = derivedAccounts[i].prvKey
-    const pubKey = getPublicKey(prvKey)
+    const pubKey = getPublicKey(hexToBytes(prvKey))
     accounts.push({
       index: i,
       type: 'derived',
@@ -976,7 +990,7 @@ function handleGetAccountsList() {
   const importedAccounts = privateMaterial.importedAccounts || []
   for (let i = 0; i < importedAccounts.length; i++) {
     const prvKey = importedAccounts[i].prvKey
-    const pubKey = getPublicKey(prvKey)
+    const pubKey = getPublicKey(hexToBytes(prvKey))
     accounts.push({
       index: i,
       type: 'imported',
@@ -1146,7 +1160,7 @@ async function handleContentScriptMessage({type, params, host, favicon}) {
         // Get the account that will be used for signing
         // If event has a pubkey, use that account; otherwise use default
         const currentAccount = await getCurrentAccount()
-        const currentPubkey = requestedPubkey || (currentAccount ? getPublicKey(currentAccount) : null)
+        const currentPubkey = requestedPubkey || (currentAccount ? getPublicKey(hexToBytes(currentAccount)) : null)
 
         // Get account name and picture from profile cache if available
         let accountName = ''
@@ -1222,7 +1236,7 @@ async function handleContentScriptMessage({type, params, host, favicon}) {
   try {
     switch (type) {
       case 'getPublicKey': {
-        return getPublicKey(activeAccount)
+        return getPublicKey(hexToBytes(activeAccount))
       }
       case 'signEvent': {
         // Use the account matching event.pubkey if available, otherwise default
@@ -1238,7 +1252,7 @@ async function handleContentScriptMessage({type, params, host, favicon}) {
           }
         }
 
-        const event = finalizeEvent(params.event, signingKey)
+        const event = finalizeEvent(params.event, hexToBytes(signingKey))
 
         return validateEvent(event)
           ? event
@@ -1246,11 +1260,11 @@ async function handleContentScriptMessage({type, params, host, favicon}) {
       }
       case 'nip04.encrypt': {
         let {peer, plaintext} = params
-        return nip04.encrypt(activeAccount, peer, plaintext)
+        return nip04.encrypt(hexToBytes(activeAccount), peer, plaintext)
       }
       case 'nip04.decrypt': {
         let {peer, ciphertext} = params
-        return nip04.decrypt(activeAccount, peer, ciphertext)
+        return nip04.decrypt(hexToBytes(activeAccount), peer, ciphertext)
       }
       case 'nip44.encrypt': {
         const {peer, plaintext} = params

--- a/src/background.jsx
+++ b/src/background.jsx
@@ -3,6 +3,7 @@ import {validateEvent, finalizeEvent, getPublicKey} from 'nostr-tools/pure'
 import * as nip19 from 'nostr-tools/nip19'
 import * as nip04 from 'nostr-tools/nip04'
 import * as nip44 from 'nostr-tools/nip44'
+import {hexToBytes} from 'nostr-tools/utils'
 import {Mutex} from 'async-mutex'
 import {LRUCache} from './utils'
 
@@ -28,20 +29,6 @@ import {
 
 import { clearAllCaches as clearProfileCaches, persistEncryptedCachesWithKey, restoreEncryptedCachesWithKey } from './services/cache'
 import { closeDiscoveryPool } from './helpers/outbox'
-
-/**
- * Convert a hex-encoded private key string to Uint8Array.
- * nostr-tools v2 changed its API to require Uint8Array for all private key
- * parameters (getPublicKey, finalizeEvent, nip04, nip44).  Vault data stores
- * private keys as hex strings, so we convert at every call site.
- */
-function hexToBytes(hex) {
-  const bytes = new Uint8Array(hex.length / 2)
-  for (let i = 0; i < bytes.length; i++) {
-    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16)
-  }
-  return bytes
-}
 
 let openPrompt = null
 let promptMutex = new Mutex()

--- a/src/content-script.jsx
+++ b/src/content-script.jsx
@@ -23,14 +23,26 @@ window.addEventListener('message', async message => {
   // pass on to background
   var response
   try {
-    response = await browser.runtime.sendMessage({
-      type: message.data.type,
-      params: message.data.params,
-      host: location.host,
-      favicon: getFavicon()
-    })
+    // Guard: check that the extension runtime is still valid before sending.
+    // In Brave (and Chrome) with MV3 service workers the runtime context can
+    // become "invalidated" after a SW restart or extension update.  When that
+    // happens chrome.runtime.id is undefined and the polyfill throws instead
+    // of letting the browser wake the SW back up.
+    if (!chrome?.runtime?.id) {
+      response = {error: {message: 'Extension context invalidated. Please reload the page.'}}
+    } else {
+      response = await browser.runtime.sendMessage({
+        type: message.data.type,
+        params: message.data.params,
+        host: location.host,
+        favicon: getFavicon()
+      })
+    }
   } catch (error) {
-    response = {error}
+    // Serialize the error as a plain object – Error instances lose their
+    // .message when crossing the content-script/page isolated-world boundary
+    // via postMessage in some Chromium / Brave versions (JSON.stringify gives {}).
+    response = {error: {message: error.message || String(error)}}
   }
 
   // return response

--- a/src/contexts/MainContext.jsx
+++ b/src/contexts/MainContext.jsx
@@ -94,7 +94,7 @@ export const MainProvider = ({ children }) => {
     const derivedAccounts = vault.accounts || []
     for (let i = 0; i < derivedAccounts.length; i++) {
       const prvKey = derivedAccounts[i].prvKey
-      const pubKey = getPublicKey(prvKey)
+      const pubKey = getPublicKey(hexToBytes(prvKey))
       loadAccounts.push({
         index: i,
         name: '',
@@ -112,7 +112,7 @@ export const MainProvider = ({ children }) => {
     const importedAccounts = vault.importedAccounts || []
     for (let i = 0; i < importedAccounts.length; i++) {
       const prvKey = importedAccounts[i].prvKey
-      const pubKey = getPublicKey(prvKey)
+      const pubKey = getPublicKey(hexToBytes(prvKey))
       loadAccounts.push({
         index: i,
         name: '',

--- a/src/modals/DeriveAccountModal.jsx
+++ b/src/modals/DeriveAccountModal.jsx
@@ -85,7 +85,7 @@ const DeriveAccountModal = ({ isOpen, onClose, callBack }) => {
         }),
       }
 
-      const signedEvent = finalizeEvent(event, prvKey)
+      const signedEvent = finalizeEvent(event, hexToBytes(prvKey))
       await Promise.any(pool.publish(relays, signedEvent))
     }
 

--- a/src/modals/EditAccountModal.jsx
+++ b/src/modals/EditAccountModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react'
 import { toast } from 'react-toastify'
 import { finalizeEvent } from 'nostr-tools/pure'
+import { hexToBytes } from 'nostr-tools/utils'
 import Modal from './Modal'
 import { pool } from '../common'
 import { getWriteRelays } from '../helpers/outbox'
@@ -70,7 +71,7 @@ const EditAccountModal = ({ isOpen, onClose, accountData, callBack }) => {
         content: JSON.stringify(profileContent),
       }
 
-      const signedEvent = finalizeEvent(event, accountData.prvKey)
+      const signedEvent = finalizeEvent(event, hexToBytes(accountData.prvKey))
       await Promise.any(pool.publish(relays, signedEvent))
 
       // Update profile cache with new data

--- a/src/pages/RelaysPage.jsx
+++ b/src/pages/RelaysPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useContext, useRef } from 'react'
 import { toast } from 'react-toastify'
 import { finalizeEvent } from 'nostr-tools/pure'
+import { hexToBytes } from 'nostr-tools/utils'
 import Loading from '../components/Loading'
 import MainContext from '../contexts/MainContext'
 import { getSessionVault } from '../common'
@@ -144,7 +145,7 @@ const RelaysPage = () => {
       }
 
       const event = createRelayListEvent(relays)
-      const signedEvent = finalizeEvent(event, vault.accountDefault)
+      const signedEvent = finalizeEvent(event, hexToBytes(vault.accountDefault))
 
       // Publish to current write relays + all discovery relays for visibility
       const writeRelays = relays.filter(r => r.write).map(r => r.url)

--- a/src/prompt.jsx
+++ b/src/prompt.jsx
@@ -9,6 +9,7 @@ import {
   getSessionVault
 } from './common'
 import {getPublicKey} from 'nostr-tools/pure'
+import {hexToBytes} from 'nostr-tools/utils'
 
 function shortenPubkey(pubkey) {
   if (!pubkey) return ''
@@ -85,7 +86,7 @@ function Prompt() {
     try {
       const vault = await getSessionVault()
       if (vault?.accountDefault) {
-        const pk = getPublicKey(vault.accountDefault)
+        const pk = getPublicKey(hexToBytes(vault.accountDefault))
         setCurrentPubkey(pk)
       }
     } catch (err) {


### PR DESCRIPTION
nostr-tools v2.0.0 changed all private-key parameters from hex strings to Uint8Array. The vault stores keys as hex, so every call site that passed a private key directly to a nostr-tools function was throwing 'expected Uint8Array, got type=string', causing:
  - Loading hang after login (GET_ACCOUNTS_LIST failed silently)
  - getPublicKey / signEvent / nip04 / nip44 all rejected from the page

Changes:
- src/background.jsx: add hexToBytes() helper and apply it at all 9 call sites: getPublicKey (x5), finalizeEvent, nip04.encrypt, nip04.decrypt, nip44.v2.utils.getConversationKey
- src/content-script.jsx: convert caught Error to a plain object {message} before postMessage so the error string survives the isolated-world boundary in Brave/Chromium (Error instances serialize to {} via JSON and can lose .message crossing worlds). Also add a chrome.runtime.id pre-check to surface a clear 'please reload' message when the MV3 service worker context is invalidated.
- dist/nostr-provider.js: only cache _pubkey after a successful call so a failed getPublicKey() does not prevent future retries.